### PR TITLE
changed matt's website address

### DIFF
--- a/src/modules/students.js
+++ b/src/modules/students.js
@@ -35,7 +35,7 @@ export default [
             "quoteAuthor": "-Arnold Schwarzenegger",
             "github": "https://github.com/MatthewScott32",
             "linkedIn": "https://www.linkedin.com/in/matthew-blagg/",
-            "portfolio": "https://matthewblagg.github.io/",
+            "portfolio": "https://matthewscott32.github.io/matthewblagg.github.io/",
             "email": "matthewscottblagg@gmail.com",
             "proImg": "matthew_serious.png",
             "funImg": "matthew_fun.png",


### PR DESCRIPTION
I changed Matt's personal site address. Please make sure when you click on his portfolio icon that it takes you here: https://matthewscott32.github.io/matthewblagg.github.io/. Make sure all other elements on the site look fine as well. 